### PR TITLE
Fix for "Error setting option fps to value 0."

### DIFF
--- a/MovieBarCodeGenerator/Core/FfmpegWrapper.cs
+++ b/MovieBarCodeGenerator/Core/FfmpegWrapper.cs
@@ -116,7 +116,7 @@ namespace MovieBarCodeGenerator.Core
             var fps = frameCount / length.TotalSeconds;
 
             // Output a raw stream of bitmap images taken at the specified frequency
-            var args = $"-i \"{inputPath}\" -vf fps={fps} -c:v bmp -f rawvideo -an -";
+            var args = $"-i \"{inputPath}\" -vf fps={fps.ToString(System.Globalization.CultureInfo.InvariantCulture)} -c:v bmp -f rawvideo -an -";
 
             var process = StartFfmpegInstance(args, redirectError: log != null);
 


### PR DESCRIPTION
The error occurred in cultures that use a different decimal separator (like comma). FFmpeg then interprets the FPS as 0.